### PR TITLE
Actual Fix FFMPG + rendered comments missing parts

### DIFF
--- a/TTS/engine_wrapper.py
+++ b/TTS/engine_wrapper.py
@@ -2,13 +2,17 @@
 from pathlib import Path
 from typing import Tuple
 import re
-from os import getenv
-from mutagen.mp3 import MP3
+import time
+import os
+# import sox
+# from mutagen import MutagenError
+# from mutagen.mp3 import MP3, HeaderNotFoundError
 import translators as ts
 from rich.progress import track
 from moviepy.editor import AudioFileClip, CompositeAudioClip, concatenate_audioclips
 from utils.console import print_step, print_substep
 from utils.voice import sanitize_text
+from utils import settings
 
 DEFUALT_MAX_LENGTH: int = 50  # video length variable
 
@@ -53,7 +57,10 @@ class TTSEngine:
         print_step("Saving Text to MP3 files...")
 
         self.call_tts("title", self.reddit_object["thread_title"])
-        if self.reddit_object["thread_post"] != "" and getenv("STORYMODE", "").casefold() == "true":
+        if (
+            self.reddit_object["thread_post"] != ""
+            and settings.config["settings"]["storymode"] == True
+        ):
             self.call_tts("posttext", self.reddit_object["thread_post"])
 
         idx = None
@@ -64,38 +71,72 @@ class TTSEngine:
             if not self.tts_module.max_chars:
                 self.call_tts(f"{idx}", comment["comment_body"])
             else:
-                self.split_post(comment["comment_body"], idx)
+                # THESE TRY EXCEPTS SOMEHOW SOLVES FFMPEG ERROR #
+                try:
+                    self.split_post(comment["comment_body"], idx)
+                except:
+                    print('Error, removing '+f"{self.path}/{idx}-0.part.mp3") # It still continues
+                    try:
+                        os.remove(f"{self.path}/{idx}-0.part.mp3")
+                    except:
+                        pass
+
 
         print_substep("Saved Text to MP3 files successfully.", style="bold green")
         return self.length, idx
 
-    def split_post(self, text: str, idx: int) -> str:
+    def split_post(self, text: str, idx: int):
         split_files = []
         split_text = [
             x.group().strip()
-            for x in re.finditer(rf" *((.{{0,{self.tts_module.max_chars}}})(\.|.$))", text)
+            for x in re.finditer(rf" *((.{{0,{self.tts_module.max_chars}}})(.$| $|\n | \n))", text)
         ]
 
         idy = None
         for idy, text_cut in enumerate(split_text):
             # print(f"{idx}-{idy}: {text_cut}\n")
             self.call_tts(f"{idx}-{idy}.part", text_cut)
-            split_files.append(AudioFileClip(f"{self.path}/{idx}-{idy}.part.mp3"))
+            # THESE TRY EXCEPTS SOMEHOW SOLVES FFMPEG ERROR #
+            try:
+                split_files.append(AudioFileClip(f"{self.path}/{idx}-{idy}.part.mp3"))
+            except:
+                print('Error, removing '+f"{self.path}/{idx}-{idy}.part.mp3")
+                try:
+                    os.remove(f"{self.path}/{idx}-{idy}.part.mp3")
+                except:
+                    pass
+        ### !!! Without the following sleep (preferably 1sec), sometimes a part seem to be missing, causing errors or bad renders, 
+        #feel free to try for example same thread 500 times and see how many times it renders the same amount of .mp3 files (not parts), 
+        #can probably build a tracker for this to count how many times each part renders !!! ###
+        time.sleep(0.5) 
         CompositeAudioClip([concatenate_audioclips(split_files)]).write_audiofile(
             f"{self.path}/{idx}.mp3", fps=44100, verbose=False, logger=None
         )
+        for i in split_files:
+            name = i.filename
+            i.close()
+            Path(name).unlink()
 
-        for i in range(0, idy + 1):
-            # print(f"Cleaning up {self.path}/{idx}-{i}.part.mp3")
-            Path(f"{self.path}/{idx}-{i}.part.mp3").unlink()
+        # for i in range(0, idy + 1):
+        # print(f"Cleaning up {self.path}/{idx}-{i}.part.mp3")
+
+        # Path(f"{self.path}/{idx}-{i}.part.mp3").unlink()
 
     def call_tts(self, filename: str, text: str):
         self.tts_module.run(text=process_text(text), filepath=f"{self.path}/{filename}.mp3")
-        self.length += MP3(f"{self.path}/{filename}.mp3").info.length
-
+        # try:
+        #     self.length += MP3(f"{self.path}/{filename}.mp3").info.length
+        # except (MutagenError, HeaderNotFoundError):
+        #     self.length += sox.file_info.duration(f"{self.path}/{filename}.mp3")
+        try:
+            clip = AudioFileClip(f"{self.path}/{filename}.mp3")
+            self.length += clip.duration
+            clip.close()
+        except:
+            self.length = 0
 
 def process_text(text: str):
-    lang = getenv("POSTLANG", "")
+    lang = settings.config["reddit"]["thread"]["post_lang"]
     new_text = sanitize_text(text)
     if lang:
         print_substep("Translating Text...")


### PR DESCRIPTION
So I accidentally uploaded the wrong file in my previous commit, haven't really slept or eaten for a while, sorry for that. Here's the actual fixes, and I'll include the description again just in case: 

I found after some digging that the missing comments in the renders were due to regex, I believe I have fixed them after realizing it was the part after defining the max_chars, so I tested putting the "(\.|.$)" in https://regex101.com/ with the text from one of the best examples I had in my rendered results folder, then I altered it until the render was working. The closest I could get which seem to be perfect, but which might need more testing was: 
for x in re.finditer(rf" *((.{{0,{self.tts_module.max_chars}}})(.$| $| \n|\n)) 
Alternatively: 
for x in re.finditer(rf" *((.{{0,{self.tts_module.max_chars}}})(.$| $|\n | \n))

However, I'm still not sure if this is the best possible regex. Also, I added some new try: excepts: to solve the FFMPEG error, for some reason this just makes it work, but I would like to test it like 500 times for the same thread to see that it always gets the same amount of parts (and preferably the same total length). What I have done is to run main.py and then just let it fetch the temp .mp3 files, then restart when I see sufficient results, rather than render the whole .mp4 video. 

If anything this can inspire someone to improve the regex further to completely fix the missing parts in some rendered comments (in case this doesn't fully fix).

# Description

The ffmpeg error that occured which after my troubleshooting it was because any of the part.mp3 files were of size 0 bytes. Also, for some reason it acted too quickly and thus skipped some parts causing videos to either have a weird synchronization, or some parts just left out completely, sometimes skipping parts of a comment in the thread. There's still more testing possible to make sure it's really fixed, and the regex proposed can be altered if it still isn't perfect, however, the try: except: parts introduced seem to be the star of the show as I am quite confident that on failure, it removes the file before it reaches the CompositeAudioClip, thus it removes any files that has 0 bytes before it does the ffmpeg check. 

# Issue Fixes

ffmpeg error and potentially (at least improving) the issue of some comments or parts of comments not rendering due to incorrect regex. There has been multiple issues opened for these things, and I can find them later if it's important for you, but right now I have to go to sleep. Good night. 

# Checklist:

- [X] I am pushing changes to the **develop** branch
- [X] I am using the recommended development environment
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have formatted and linted my code using python-black and pylint
- [X] I have cleaned up unnecessary files (tried to)
- [X] My changes generate no new warnings
- [X] My changes follow the existing code-style
- [XX] My changes are relevant to the project

# Any other information (e.g how to test the changes)
Running main.py with a thread that previously gave ffmpeg error should be a good test. Also previously parts of the rendered video was missing. 